### PR TITLE
refactor(other): replace vuepress deploy action

### DIFF
--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -1,0 +1,22 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+
+    - name: vuepress-gh-pages-deploy
+      uses: crazy-max/ghaction-github-pages@master
+      with:
+        target_branch: gh-pages
+        build_dir: docs/.vuepress/dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## 🍰 Pullrequest
The utilzed Vuepress2 Pugins require a NodeJS version `>=18.16.0` ((see [this failing workflow](https://github.com/Ocelot-Social-Community/ocelot.social/actions/runs/7030578801/job/19130400860))), but the Github Action XX uses a [NodeJS-16-based Dockerfile](url).

The [Vuepress2 Documentation](https://v2.vuepress.vuejs.org/guide/deployment.html#github-pages) recommends to use [crazy-max/ghaction-github-pages](https://github.com/crazy-max/ghaction-github-pages) for Deloyment.

