### PR TITLE
refactor(other): adapt seo and redirect plugin config to theme changes

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,12 +3,12 @@ import { viteBundler } from '@vuepress/bundler-vite'
 
 import meta from './config/meta'
 import theme from './config/theme'
-import plugins from './config/plugins'
+// import plugins from './config/plugins'
 
 export default defineUserConfig({
   ...meta,
   theme,
-  plugins,
+  // plugins,
   bundler: viteBundler(),
   base: process.env.VUEPRESS_BASE ? `/${process.env.VUEPRESS_BASE}/` : '/',
   locales: {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,12 +3,10 @@ import { viteBundler } from '@vuepress/bundler-vite'
 
 import meta from './config/meta'
 import theme from './config/theme'
-// import plugins from './config/plugins'
 
 export default defineUserConfig({
   ...meta,
   theme,
-  // plugins,
   bundler: viteBundler(),
   base: process.env.VUEPRESS_BASE ? `/${process.env.VUEPRESS_BASE}/` : '/',
   locales: {

--- a/docs/.vuepress/config/plugins.js
+++ b/docs/.vuepress/config/plugins.js
@@ -1,8 +1,0 @@
-import { redirectPlugin } from '@vuepress/plugin-redirect'
-
-
-export default [
-  redirectPlugin({
-    autoLocale: true,
-  })
-]

--- a/docs/.vuepress/config/theme.js
+++ b/docs/.vuepress/config/theme.js
@@ -99,6 +99,9 @@ export default hopeTheme({
       sup: true,
       vPre: true,
     },
+    redirect: {
+      autoLocale: true,
+    },
     searchPro: {
       indexContent: true,
       autoSuggestions: true,

--- a/docs/.vuepress/config/theme.js
+++ b/docs/.vuepress/config/theme.js
@@ -114,7 +114,8 @@ export default hopeTheme({
       ],
     },
     seo: {
-      fallbackImage: '/logo.svg'
+      fallbackImage: '/logo.svg',
+      hostname: 'https://ocelot.social/'
     }
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@textlint-rule/textlint-rule-no-unmatched-pair": "^2.0.2",
         "@vuepress/bundler-vite": "^2.0.0-rc.9",
-        "@vuepress/plugin-redirect": "^2.0.0-rc.23",
+        "@vuepress/plugin-redirect": "^2.0.0-rc.29",
         "textlint": "^14.0.4",
         "textlint-filter-rule-comments": "^1.2.2",
         "textlint-rule-apostrophe": "^2.0.0",
@@ -27,8 +27,8 @@
         "textlint-rule-period-in-list-item": "^1.0.1",
         "textlint-rule-write-good": "^2.0.0",
         "vuepress": "^2.0.0-rc.9",
-        "vuepress-plugin-search-pro": "^2.0.0-rc.33",
-        "vuepress-theme-hope": "^2.0.0-rc.40"
+        "vuepress-plugin-search-pro": "^2.0.0-rc.43",
+        "vuepress-theme-hope": "^2.0.0-rc.43"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2295,18 +2295,6 @@
         "vuepress": "2.0.0-rc.9"
       }
     },
-    "node_modules/@vuepress/plugin-external-link-icon": {
-      "version": "2.0.0-rc.28",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-external-link-icon/-/plugin-external-link-icon-2.0.0-rc.28.tgz",
-      "integrity": "sha512-VEEQEaMZzGOh8q1oR9u18gIBK7pbkCSx02vEN0k/cvRbfKbMdayEOTk4x+5Sy/A/fUcBPRbyw8O+/nDVzLn4pg==",
-      "dev": true,
-      "dependencies": {
-        "vue": "^3.4.27"
-      },
-      "peerDependencies": {
-        "vuepress": "2.0.0-rc.9"
-      }
-    },
     "node_modules/@vuepress/plugin-git": {
       "version": "2.0.0-rc.22",
       "resolved": "https://registry.npmjs.org/@vuepress/plugin-git/-/plugin-git-2.0.0-rc.22.tgz",
@@ -2373,9 +2361,9 @@
       }
     },
     "node_modules/@vuepress/plugin-prismjs": {
-      "version": "2.0.0-rc.21",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-rc.21.tgz",
-      "integrity": "sha512-dMTCu/TZ1QCmTHXL4THVeh9gWzuqkJV8qhck5U77OP1qmgyf+r529A+MTOgp3ddcph1Yzb/FRb2orlefHk+yNQ==",
+      "version": "2.0.0-rc.28",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-prismjs/-/plugin-prismjs-2.0.0-rc.28.tgz",
+      "integrity": "sha512-CsKBmGRnY+h3iElxdi1Te4g6pzfSdBePBLWXq89IqOchFI5sOabJWKso0R5bnE1mDdT2doGjDmDvzrUZvaoK+w==",
       "dev": true,
       "dependencies": {
         "prismjs": "^1.29.0"
@@ -7170,9 +7158,9 @@
       }
     },
     "node_modules/vuepress-plugin-components": {
-      "version": "2.0.0-rc.40",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-components/-/vuepress-plugin-components-2.0.0-rc.40.tgz",
-      "integrity": "sha512-FMfkQpCgzBezYFdH5Wlt3wzEEztnMYoz6UJeO4CQh9Nm3da2Qu7ov5X2338daVEIBeIsk0tpEZ7iYQa8kZShMQ==",
+      "version": "2.0.0-rc.43",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-components/-/vuepress-plugin-components-2.0.0-rc.43.tgz",
+      "integrity": "sha512-0bS3GewYVL0ih5jqnDhWva2dEr/+bPAnMHz5FXM+KTD1mhIFSvdJF1G4Wn4kTmEMMnDYUP+Vfrh1gyVOs4SHIA==",
       "dev": true,
       "dependencies": {
         "@stackblitz/sdk": "^1.10.0",
@@ -7183,7 +7171,7 @@
         "create-codepen": "1.0.1",
         "qrcode": "^1.5.3",
         "vue": "^3.4.27",
-        "vuepress-shared": "2.0.0-rc.39"
+        "vuepress-shared": "2.0.0-rc.43"
       },
       "engines": {
         "node": ">=18.19.0",
@@ -7222,9 +7210,9 @@
       }
     },
     "node_modules/vuepress-plugin-md-enhance": {
-      "version": "2.0.0-rc.39",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-md-enhance/-/vuepress-plugin-md-enhance-2.0.0-rc.39.tgz",
-      "integrity": "sha512-OKJcYXyZSiYBI/cZjx04TdRkKDKLqt9k+tpSNpwZLG2PI7NowOw/HQBZzTONDayRhtPhMy4519Cb0o0F8uogaw==",
+      "version": "2.0.0-rc.43",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-md-enhance/-/vuepress-plugin-md-enhance-2.0.0-rc.43.tgz",
+      "integrity": "sha512-VH8xB0U4u5A9uPhjDyO54iEphpPEMlRmr75k29eh9SJ/Bc7FeX36VSzZG6xGDhY2Vepb48q3kEkULv2tT6qIjw==",
       "dev": true,
       "dependencies": {
         "@mdit/plugin-alert": "^0.10.1",
@@ -7257,7 +7245,7 @@
         "balloon-css": "^1.2.0",
         "js-yaml": "^4.1.0",
         "vue": "^3.4.27",
-        "vuepress-shared": "2.0.0-rc.39"
+        "vuepress-shared": "2.0.0-rc.43"
       },
       "engines": {
         "node": ">=18.19.0",
@@ -7360,9 +7348,9 @@
       }
     },
     "node_modules/vuepress-plugin-search-pro": {
-      "version": "2.0.0-rc.39",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-search-pro/-/vuepress-plugin-search-pro-2.0.0-rc.39.tgz",
-      "integrity": "sha512-d3thn/YJNiqZm9S+Qu7KANNRgk2Wn2ZoWMk6BV+ONM6eeXimHEmeNEzBTMUDeJwZHdxewo9Szr9Dqgl4YUL4/w==",
+      "version": "2.0.0-rc.43",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-search-pro/-/vuepress-plugin-search-pro-2.0.0-rc.43.tgz",
+      "integrity": "sha512-ZJrhTyIRtz5Gisc9PdrjIdkUVC3EOYKpZbauPUNWceQ8JkBoRWweu90V7DNrOMfdgVNHJ8ToAuJa71udx+slIw==",
       "dev": true,
       "dependencies": {
         "@vuepress/helper": "2.0.0-rc.28",
@@ -7372,7 +7360,7 @@
         "chokidar": "^3.6.0",
         "slimsearch": "^2.1.1",
         "vue": "^3.4.27",
-        "vuepress-shared": "2.0.0-rc.39"
+        "vuepress-shared": "2.0.0-rc.43"
       },
       "engines": {
         "node": ">=18.19.0",
@@ -7391,19 +7379,19 @@
       }
     },
     "node_modules/vuepress-shared": {
-      "version": "2.0.0-rc.39",
-      "resolved": "https://registry.npmjs.org/vuepress-shared/-/vuepress-shared-2.0.0-rc.39.tgz",
-      "integrity": "sha512-F3C4cLHB8f147FwJ5HoHNjc+Tka3VHPnjUzOka/D+X13NQMpA72vsjph0q4hVVwUsq2ftQTVKxl5NSm7qgtCYg==",
+      "version": "2.0.0-rc.43",
+      "resolved": "https://registry.npmjs.org/vuepress-shared/-/vuepress-shared-2.0.0-rc.43.tgz",
+      "integrity": "sha512-xZlgM5UvBGhwfKPdBl+wPIox/QP0hBc+WvAb6YXAwY3SKp6+C6TvvXd1l4taCUz8XHNWNTWiKu/9kwQGjgAUAg==",
       "dev": true,
       "dependencies": {
         "@vuepress/helper": "2.0.0-rc.28",
         "@vueuse/core": "^10.9.0",
         "cheerio": "1.0.0-rc.12",
         "dayjs": "^1.11.11",
-        "execa": "^9.0.0",
+        "execa": "^9.0.2",
         "fflate": "^0.8.2",
         "gray-matter": "^4.0.3",
-        "semver": "^7.6.1",
+        "semver": "^7.6.2",
         "vue": "^3.4.27"
       },
       "engines": {
@@ -7429,9 +7417,9 @@
       }
     },
     "node_modules/vuepress-shared/node_modules/execa": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.0.2.tgz",
-      "integrity": "sha512-oO281GF7ksH/Ogv1xyDf1prvFta/6/XkGKxRUvA3IB2MU1rCJGlFs86HRZhdooow1ISkR0Np0rOxUCIJVw36Rg==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.1.0.tgz",
+      "integrity": "sha512-lSgHc4Elo2m6bUDhc3Hl/VxvUDJdQWI40RZ4KMY9bKRc+hgMOT7II/JjbNDhI8VnMtrCb7U/fhpJIkLORZozWw==",
       "dev": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -7540,9 +7528,9 @@
       }
     },
     "node_modules/vuepress-theme-hope": {
-      "version": "2.0.0-rc.40",
-      "resolved": "https://registry.npmjs.org/vuepress-theme-hope/-/vuepress-theme-hope-2.0.0-rc.40.tgz",
-      "integrity": "sha512-u3r1QI1BvqQRWtoMn+rt3BVsC25crCsxMvRh1uuQQzUOF4E9IndADoG0KnLdL/1kTDH1bFJwfxV32sEIeu2VSg==",
+      "version": "2.0.0-rc.43",
+      "resolved": "https://registry.npmjs.org/vuepress-theme-hope/-/vuepress-theme-hope-2.0.0-rc.43.tgz",
+      "integrity": "sha512-9PZXFCK2XHGXytXpBchyxhxQEPNPAHgQFAwVJeI3yrPZd3zIRBAm/NAqdl0oGD9YwuIb20tI56vs6CXhOzUxKg==",
       "dev": true,
       "dependencies": {
         "@vuepress/helper": "2.0.0-rc.28",
@@ -7553,13 +7541,12 @@
         "@vuepress/plugin-comment": "2.0.0-rc.28",
         "@vuepress/plugin-copy-code": "2.0.0-rc.28",
         "@vuepress/plugin-copyright": "2.0.0-rc.28",
-        "@vuepress/plugin-external-link-icon": "2.0.0-rc.28",
         "@vuepress/plugin-git": "2.0.0-rc.22",
         "@vuepress/plugin-links-check": "2.0.0-rc.28",
         "@vuepress/plugin-notice": "2.0.0-rc.29",
         "@vuepress/plugin-nprogress": "2.0.0-rc.28",
         "@vuepress/plugin-photo-swipe": "2.0.0-rc.28",
-        "@vuepress/plugin-prismjs": "2.0.0-rc.21",
+        "@vuepress/plugin-prismjs": "2.0.0-rc.28",
         "@vuepress/plugin-reading-time": "2.0.0-rc.28",
         "@vuepress/plugin-rtl": "2.0.0-rc.28",
         "@vuepress/plugin-sass-palette": "2.0.0-rc.28",
@@ -7574,9 +7561,9 @@
         "chokidar": "^3.6.0",
         "gray-matter": "^4.0.3",
         "vue": "^3.4.27",
-        "vuepress-plugin-components": "2.0.0-rc.40",
-        "vuepress-plugin-md-enhance": "2.0.0-rc.39",
-        "vuepress-shared": "2.0.0-rc.39"
+        "vuepress-plugin-components": "2.0.0-rc.43",
+        "vuepress-plugin-md-enhance": "2.0.0-rc.43",
+        "vuepress-shared": "2.0.0-rc.43"
       },
       "engines": {
         "node": ">=18.19.0",
@@ -7593,7 +7580,7 @@
         "nodejs-jieba": "^0.1.2",
         "sass-loader": "^14.0.0",
         "vuepress": "2.0.0-rc.9",
-        "vuepress-plugin-search-pro": "2.0.0-rc.39"
+        "vuepress-plugin-search-pro": "2.0.0-rc.43"
       },
       "peerDependenciesMeta": {
         "@vuepress/plugin-docsearch": {
@@ -7951,9 +7938,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.0.tgz",
-      "integrity": "sha512-esbDnt0Z1zI1KgvOZU90hJbL6BkoUbrP9yy7ArNZ6TmxBxydMJTYMf9FZjmwwcA8ZgEQzriQ3hwZ0NYXhlFo8Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.0.2.tgz",
+      "integrity": "sha512-Ct97huExsu7cWeEjmrXlofevF8CvzUglJ4iGUet5B8xn1oumtAZBpHU4GzYuoE6PVqcZ5hghtBrSlhwHuR1Jmw==",
       "dev": true,
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@textlint-rule/textlint-rule-no-unmatched-pair": "^2.0.2",
     "@vuepress/bundler-vite": "^2.0.0-rc.9",
-    "@vuepress/plugin-redirect": "^2.0.0-rc.23",
+    "@vuepress/plugin-redirect": "^2.0.0-rc.29",
     "textlint": "^14.0.4",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-apostrophe": "^2.0.0",
@@ -37,7 +37,7 @@
     "textlint-rule-period-in-list-item": "^1.0.1",
     "textlint-rule-write-good": "^2.0.0",
     "vuepress": "^2.0.0-rc.9",
-    "vuepress-plugin-search-pro": "^2.0.0-rc.33",
-    "vuepress-theme-hope": "^2.0.0-rc.40"
+    "vuepress-plugin-search-pro": "^2.0.0-rc.43",
+    "vuepress-theme-hope": "^2.0.0-rc.43"
   }
 }


### PR DESCRIPTION
## 🍰 Pullrequest
Building the Vuepress docs throws these errors:
```
@vuepress/plugin-seo:  ✖ Option hostname is required!
vuepress-theme-hope:  ✖ You are not allowed to use plugin "@vuepress/plugin-redirect" yourself in vuepress config file. Set "plugins.redirect" in theme options to customize it.
```

### Todo
- [X] set hostname in SEO plugin config
- [x] move redirect plugin config to theme config
